### PR TITLE
Fix UnicodeDecodeError when loading JSON file

### DIFF
--- a/status.py
+++ b/status.py
@@ -22,7 +22,7 @@ class myBot(commands.Bot):
 
 bot = myBot(intents = intents, command_prefix = '!')
 
-with open('config.json') as f:
+with open('config.json', 'r', encoding='utf-8') as f:
     config = json.load(f)
 
 TOKEN = config['token']


### PR DESCRIPTION
The issue was caused by the default encoding not being suitable for decoding certain characters in the JSON file. Specified UTF-8 encoding explicitly when opening the file to ensure proper decoding.